### PR TITLE
lang/go: golang booklist added

### DIFF
--- a/src/lang/go.md
+++ b/src/lang/go.md
@@ -3,3 +3,4 @@
 * [A Tour of Go](https://tour.golang.org/)
 * [Learn Go](https://learn.go.dev)
 * [Gophercises](https://gophercises.com/)
+* [Books for Golang](https://github.com/dariubs/GoBooks)


### PR DESCRIPTION
Added link for a GitHub [repo](https://github.com/dariubs/GoBooks) which collates a list of books with their short description. The repo is actively maintained.